### PR TITLE
Refactor - remove redundant `to_d`

### DIFF
--- a/lib/services/ecf/ecf_payment_calculation_service.rb
+++ b/lib/services/ecf/ecf_payment_calculation_service.rb
@@ -42,7 +42,7 @@ private
 
   def service_fee_monthly
     number_of_service_fee_payments = 29
-    (service_fee_total / number_of_service_fee_payments).round(0).to_d
+    (service_fee_total / number_of_service_fee_payments).round(0)
   end
 
   def variable_payment_per_participant


### PR DESCRIPTION
Refactor - remove redundant `to_d`

This cast isn't needed.

We are asserting the output type in another spec and the test still passes as the output remains BigDecimal with this patch in place.