### PR TITLE
Convert payment_schedule from a hash to an array

### DIFF
--- a/lib/services/npq/service_fees.rb
+++ b/lib/services/npq/service_fees.rb
@@ -23,9 +23,7 @@ module Services
       end
 
       def service_fee_payment_schedule
-        (1..number_of_service_fee_payments).each_with_object({}) do |i, schedule|
-          schedule[i] = monthly_service_fee
-        end
+        [monthly_service_fee] * number_of_service_fee_payments
       end
     end
   end

--- a/spec/lib/services/npq/service_fee_schedule_spec.rb
+++ b/spec/lib/services/npq/service_fee_schedule_spec.rb
@@ -32,7 +32,7 @@ describe Services::Npq::PaymentCalculation do
     end
 
     it "returns BigDecimal for all money outputs" do
-      result.dig(:output, :service_fees, :payment_schedule).each do |_key, value|
+      result.dig(:output, :service_fees, :payment_schedule).each do |value|
         expect(value).to be_a(BigDecimal)
       end
     end

--- a/spec/lib/services/npq/variable_fee_schedule_spec.rb
+++ b/spec/lib/services/npq/variable_fee_schedule_spec.rb
@@ -32,7 +32,7 @@ describe Services::Npq::PaymentCalculation do
     end
 
     it "returns BigDecimal for all money outputs" do
-      result.dig(:output, :service_fees, :payment_schedule).each do |_key, value|
+      result.dig(:output, :service_fees, :payment_schedule).each do |value|
         expect(value).to be_a(BigDecimal)
       end
     end

--- a/spec/steps/npq/payment_calculation_steps.rb
+++ b/spec/steps/npq/payment_calculation_steps.rb
@@ -18,20 +18,20 @@ module PaymentCalculationSteps
     aggregate_failures "service fees" do
       total_payment = 0
       table.hashes.each do |row|
-        month = row["Month"].to_i
+        month_index = row["Month"].to_i
         expected_service_fee_total = CurrencyParser.currency_to_big_decimal(row["Service Fee"])
         total_payment += expected_service_fee_total
-        expect_with_context(result.dig(:output, :service_fees, :payment_schedule, month), expected_service_fee_total, "Payment for month '#{month}'")
+        expect_with_context(result.dig(:output, :service_fees, :payment_schedule)[month_index - 1], expected_service_fee_total, "Payment for month '#{month_index}'")
       end
 
       expect_with_context(@number_of_service_fee_payments, table.hashes.count, "Number of schedule payments")
-      expect_with_context(total_payment, result.dig(:output, :service_fees, :payment_schedule).values.sum, "Total schedule payment")
+      expect_with_context(total_payment, result.dig(:output, :service_fees, :payment_schedule).sum, "Total schedule payment")
     end
   end
 
   step "the service fee total should be £:decimal_placeholder" do |expected_amount|
     result = calculate
-    expect(result.dig(:output, :service_fees, :payment_schedule).values.sum).to eq(expected_amount)
+    expect(result.dig(:output, :service_fees, :payment_schedule).sum).to eq(expected_amount)
   end
 
   step "there are the following retention points:" do |table|


### PR DESCRIPTION
Payment_schedule was initially generated as an integer indexed hash, so it's now a standard Ruby array. This requires month lookups as index to the array ([month-1]) as opposed to using a month number as a key.