### PR TITLE
Break up ecf feature

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,4 @@ root = true
 
 [*]
 insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+
+# Used by Jetbrains for projects.
+/.idea/

--- a/lib/services/ecf/payment_calculation.rb
+++ b/lib/services/ecf/payment_calculation.rb
@@ -10,7 +10,7 @@ module Services
           input: config.to_h,
           output: {
             service_fees: ServiceFees.call(config),
-            variable_payments: VariablePayments.call(config),
+            variable_payments: VariablePaymentsAggregator.call(config),
           },
         }
       end

--- a/lib/services/ecf/variable_payments_aggregator.rb
+++ b/lib/services/ecf/variable_payments_aggregator.rb
@@ -9,10 +9,9 @@ module Services
       def call
         {
           per_participant: VariablePaymentsPerParticipant.call(config),
-          **({variable_payment_schedule: VariablePaymentsSchedule.call(config)} if retained_participants).to_h
+          **({ variable_payment_schedule: VariablePaymentsSchedule.call(config) } if retained_participants).to_h,
         }
       end
-
     end
   end
 end

--- a/lib/services/ecf/variable_payments_aggregator.rb
+++ b/lib/services/ecf/variable_payments_aggregator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Services
+  module Ecf
+    class VariablePaymentsAggregator
+      include InitializeWithConfig
+      delegate :retained_participants, to: :config
+
+      def call
+        {
+          per_participant: VariablePaymentsPerParticipant.call(config),
+          **({variable_payment_schedule: VariablePaymentsSchedule.call(config)} if retained_participants).to_h
+        }
+      end
+
+    end
+  end
+end

--- a/lib/services/ecf/variable_payments_per_participant.rb
+++ b/lib/services/ecf/variable_payments_per_participant.rb
@@ -10,12 +10,11 @@ module Services
         variable_payment_per_participant
       end
 
-      private
+    private
 
       def variable_payment_per_participant
         band_a * 0.6
       end
-
     end
   end
 end

--- a/lib/services/ecf/variable_payments_per_participant.rb
+++ b/lib/services/ecf/variable_payments_per_participant.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Services
+  module Ecf
+    class VariablePaymentsPerParticipant
+      include InitializeWithConfig
+      delegate :band_a, to: :config
+
+      def call
+        variable_payment_per_participant
+      end
+
+      private
+
+      def variable_payment_per_participant
+        band_a * 0.6
+      end
+
+    end
+  end
+end

--- a/lib/services/ecf/variable_payments_schedule.rb
+++ b/lib/services/ecf/variable_payments_schedule.rb
@@ -10,7 +10,7 @@ module Services
         variable_payment_schedule
       end
 
-      private
+    private
 
       def variable_payment_schedule
         retained_participants.each_with_object({}) do |(payment_type, number_retained), result|
@@ -33,7 +33,6 @@ module Services
       def variable_payment_per_participant
         VariablePaymentsPerParticipant.call(config)
       end
-
     end
   end
 end

--- a/lib/services/ecf/variable_payments_schedule.rb
+++ b/lib/services/ecf/variable_payments_schedule.rb
@@ -2,22 +2,15 @@
 
 module Services
   module Ecf
-    class VariablePayments
+    class VariablePaymentsSchedule
       include InitializeWithConfig
-      delegate :band_a, :retained_participants, to: :config
+      delegate :retained_participants, to: :config
 
       def call
-        {
-          per_participant: variable_payment_per_participant,
-          variable_payment_schedule: variable_payment_schedule,
-        }
+        variable_payment_schedule
       end
 
-    private
-
-      def variable_payment_per_participant
-        band_a * 0.6
-      end
+      private
 
       def variable_payment_schedule
         retained_participants.each_with_object({}) do |(payment_type, number_retained), result|
@@ -33,9 +26,14 @@ module Services
         variable_payment_per_participant * (payment_type.match(/Start|Completion/) ? 0.2 : 0.15)
       end
 
-      def variable_payment_subtotal_for(payment_type, retained_participants)
-        variable_payment_per_participant_for(payment_type) * retained_participants
+      def variable_payment_subtotal_for(payment_type, number_retained)
+        variable_payment_per_participant_for(payment_type) * number_retained
       end
+
+      def variable_payment_per_participant
+        VariablePaymentsPerParticipant.call(config)
+      end
+
     end
   end
 end

--- a/spec/features/ecf/output_payments.feature
+++ b/spec/features/ecf/output_payments.feature
@@ -1,7 +1,7 @@
 @ecf
 Feature: ECF payment calculation engine
 
-  Scenario: Calculation of payments example 1
+  Scenario: Output payments example 1
     Given the recruitment target is 2000
       And Band A per-participant price is £995
       And there are the following retention numbers:
@@ -13,13 +13,10 @@ Feature: ECF payment calculation engine
         | Retention 4  | Mar 2023 | 800                   | £89.55                                  | £71,640                          |
         | Completion   | Aug 2023 | 500                   | £119.40                                 | £59,700                          |
     When I run the calculation
-    Then the per-participant service fee should be £398
-      And the total service fee should be £796,000
-      And the monthly service fee should be £27,448
-      And the variable payment per-participant should be £597
+    Then the variable payment per-participant should be £597
       And the variable payment schedule should be as above
 
-  Scenario: Calculation of payments example 2
+  Scenario: Output payments example 2
     Given the recruitment target is 2000
       And Band A per-participant price is £1,350
       And there are the following retention numbers:
@@ -31,8 +28,6 @@ Feature: ECF payment calculation engine
         | Retention 4  | Mar 2023 | 800                   | £121.50                                 | £97,200                          |
         | Completion   | Aug 2023 | 500                   | £162.00                                 | £81,000                          |
     When I run the calculation
-    Then the per-participant service fee should be £540
-      And the total service fee should be £1,080,000
-      And the monthly service fee should be £37,241
+    Then the monthly service fee should be £37,241
       And the variable payment per-participant should be £810
       And the variable payment schedule should be as above

--- a/spec/features/ecf/service_fees.feature
+++ b/spec/features/ecf/service_fees.feature
@@ -1,0 +1,18 @@
+@ecf
+Feature: ECF payment calculation engine
+
+  Scenario: Service fees example 1
+    Given the recruitment target is 2000
+      And Band A per-participant price is £995
+    When I run the calculation
+    Then the per-participant service fee should be £398
+      And the total service fee should be £796,000
+      And the monthly service fee should be £27,448
+
+  Scenario: Service fees example 2
+    Given the recruitment target is 2000
+    And Band A per-participant price is £1,350
+    When I run the calculation
+    Then the per-participant service fee should be £540
+    And the total service fee should be £1,080,000
+    And the monthly service fee should be £37,241

--- a/spec/lib/services/ecf/payment_calculation_spec.rb
+++ b/spec/lib/services/ecf/payment_calculation_spec.rb
@@ -22,10 +22,12 @@ describe ::Services::Ecf::PaymentCalculation do
     expect(result.dig(:output, :service_fees, :service_fee_total)).to be_a(BigDecimal)
     expect(result.dig(:output, :service_fees, :service_fee_monthly)).to be_a(BigDecimal)
     expect(result.dig(:output, :variable_payments, :per_participant)).to be_a(BigDecimal)
-    result.dig(:output, :variable_payments, :variable_payment_schedule).each do |_key, value|
-      expect(value[:per_participant]).to be_a(BigDecimal)
-      expect(value[:subtotal]).to be_a(BigDecimal)
-    end if result[:output][:variable_payments]
+    if result[:output][:variable_payments]
+      result.dig(:output, :variable_payments, :variable_payment_schedule).each do |_key, value|
+        expect(value[:per_participant]).to be_a(BigDecimal)
+        expect(value[:subtotal]).to be_a(BigDecimal)
+      end
+    end
   end
 
   it "includes config in the output" do

--- a/spec/lib/services/ecf/payment_calculation_spec.rb
+++ b/spec/lib/services/ecf/payment_calculation_spec.rb
@@ -25,7 +25,7 @@ describe ::Services::Ecf::PaymentCalculation do
     result.dig(:output, :variable_payments, :variable_payment_schedule).each do |_key, value|
       expect(value[:per_participant]).to be_a(BigDecimal)
       expect(value[:subtotal]).to be_a(BigDecimal)
-    end
+    end if result[:output][:variable_payments]
   end
 
   it "includes config in the output" do

--- a/spec/steps/ecf/payment_calculation_steps.rb
+++ b/spec/steps/ecf/payment_calculation_steps.rb
@@ -24,7 +24,7 @@ module PaymentCalculationSteps
     config = {
       recruitment_target: @recruitment_target,
       band_a: @band_a,
-      retained_participants: @retention_table.reduce({}) { |res, hash| res.merge({ hash[:payment_type] => hash[:retained_participants] }) },
+      retained_participants: @retention_table&.reduce({}) { |res, hash| res.merge({ hash[:payment_type] => hash[:retained_participants] }) },
     }
     calculator = Services::Ecf::PaymentCalculation.new(config)
     @result = calculator.call


### PR DESCRIPTION
- Extract the various ECF service fees into their own discrete forms and tie the results back into an Aggregator.
- Apply Single Responsibility to classes to make each one responsible for one thing.
- Fix a couple of naming areas that could be confusing (mainly variables in the code and feature and method names).
- Made "output payment" the name of classes to match the business expectation.
